### PR TITLE
Added sidebar navigation in mobile mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 resources/_gen
 hugo
 hugo.exe
+dist

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -115,7 +115,7 @@ i.fa, i.fas, i.fab {
 }
 
 #td-sidebar-menu form {
-  margin-top: 25px;
+  margin-top: 0px;
 }
 
 .pt-2, .py-2 {
@@ -272,4 +272,8 @@ hr {
   span {
     font-weight: bold;
   }
+}
+
+.btn {
+  color: white;
 }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -115,7 +115,7 @@ i.fa, i.fas, i.fab {
 }
 
 #td-sidebar-menu form {
-  margin-top: 0px;
+  margin-top: 25px;
 }
 
 .pt-2, .py-2 {
@@ -276,4 +276,8 @@ hr {
 
 .btn {
   color: white;
+}
+
+.breadcrumb {
+  padding-top: 25px;
 }

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,3 +1,4 @@
-<form method="GET" action="/search">
+<form class="td-sidebar__search d-flex align-items-center" method="GET" action="/search">
   <input type="search" class="form-control td-search-input" name="q" placeholder="&#xf002; {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off" />
+  <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation"></button>
 </form>


### PR DESCRIPTION
There was no burger menu to view the sidebar navigation in mobile/narrow mode.
This PR adds a dynamic dropdown menu like in the [docsy example](https://github.com/google/docsy-example/)

<img width="630" alt="image" src="https://user-images.githubusercontent.com/9850952/95027112-69833680-0696-11eb-9c6c-90600fce2f8c.png">

In this process, the `docsy` submodule was updated to commit [37503b4](https://github.com/google/docsy/tree/37503b4b16381071e1941abe6079ce09837db3f2).