### PR TITLE
Renaming Conquest Assault (alt.)

### DIFF
--- a/content/hosting/maps.md
+++ b/content/hosting/maps.md
@@ -21,17 +21,17 @@ weight: 8
 | Gulf of Oman | `XP1_002` |
 | Sharqi Peninsula | `XP1_003` |
 | Wake Island | `XP1_004` |
-| Scrapmetal | `XP2_Factory` |
-| Operation 925 | `XP2_Office` |
 | Donya Fortress | `XP2_Palace` |
+| Operation 925 | `XP2_Office` |
+| Scrapmetal | `XP2_Factory` |
 | Ziba Tower | `XP2_Skybar` |
-| Bandar Desert | `XP3_Desert` |
 | Alborz Mountains | `XP3_Alborz` |
 | Armored Shield | `XP3_Shield` |
+| Bandar Desert | `XP3_Desert` |
 | Death Valley | `XP3_Valley` |
+| Azadi Palace | `XP4_Parl` |
 | Epicenter | `XP4_Quake` |
 | Markaz Monolith | `XP4_FD` |
-| Azadi Palace | `XP4_Parl` |
 | Talah Market | `XP4_Rubble` |
 | Operation Riverside | `XP5_001` |
 | Nebandan Flats | `XP5_002` |
@@ -78,17 +78,17 @@ Not every map supports every gamemode. Below is a list of what gamemodes are sup
 | `XP1_002` | `ConquestAssaultSmall0`, `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
 | `XP1_003` | `ConquestAssaultLarge0`, `ConquestAssaultSmall0`, `ConquestAssaultSmall1`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
 | `XP1_004` | `ConquestAssaultLarge0`, `ConquestAssaultSmall0`, `ConquestAssaultSmall1`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
-| `XP2_Factory` | `Domination0`, `GunMaster0`, `SquadDeathMatch0`, `TeamDeathMatchC0` |
-| `XP2_Office` | `Domination0`, `GunMaster0`, `SquadDeathMatch0`, `TeamDeathMatchC0` |
 | `XP2_Palace` | `Domination0`, `GunMaster0`, `SquadDeathMatch0`, `TeamDeathMatchC0` |
+| `XP2_Office` | `Domination0`, `GunMaster0`, `SquadDeathMatch0`, `TeamDeathMatchC0` |
+| `XP2_Factory` | `Domination0`, `GunMaster0`, `SquadDeathMatch0`, `TeamDeathMatchC0` |
 | `XP2_Skybar` | `Domination0`, `GunMaster0`, `SquadDeathMatch0`, `TeamDeathMatchC0` |
-| `XP3_Desert` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TankSuperiority0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
 | `XP3_Alborz` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TankSuperiority0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
 | `XP3_Shield` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TankSuperiority0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP3_Desert` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TankSuperiority0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
 | `XP3_Valley` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TankSuperiority0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP4_Parl` | `ConquestLarge0`, `ConquestSmall0`, `GunMaster0`, `RushLarge0`, `Scavenger0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
 | `XP4_Quake` | `ConquestLarge0`, `ConquestSmall0`, `GunMaster0`, `RushLarge0`, `Scavenger0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
 | `XP4_FD` | `ConquestLarge0`, `ConquestSmall0`, `GunMaster0`, `RushLarge0`, `Scavenger0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
-| `XP4_Parl` | `ConquestLarge0`, `ConquestSmall0`, `GunMaster0`, `RushLarge0`, `Scavenger0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
 | `XP4_Rubble` | `ConquestAssaultLarge0`, `ConquestAssaultSmall0`, `GunMaster0`, `RushLarge0`, `Scavenger0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
 | `XP5_001` | `AirSuperiority0`, `CaptureTheFlag0`, `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
 | `XP5_002` | `AirSuperiority0`, `CaptureTheFlag0`, `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |

--- a/content/hosting/maps.md
+++ b/content/hosting/maps.md
@@ -65,32 +65,32 @@ Not every map supports every gamemode. Below is a list of what gamemodes are sup
 
 | Map ID | Supported gamemodes |
 | ------ | ------------------- |
-| `MP_001` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0` |
-| `MP_003` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0` |
-| `MP_007` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0` |
-| `MP_011` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0` |
-| `MP_012` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0` |
-| `MP_013` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0` |
-| `MP_017` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0` |
-| `MP_018` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0` |
-| `MP_Subway` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0` |
-| `XP1_001` | `ConquestAssaultLarge0`, `ConquestAssaultSmall0`, `ConquestAssaultSmall1`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0` |
-| `XP1_002` | `ConquestLarge0`, `ConquestSmall0`, `ConquestAssaultSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0` |
-| `XP1_003` | `ConquestAssaultLarge0`, `ConquestAssaultSmall0`, `ConquestAssaultSmall1`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0` |
-| `XP1_004` | `ConquestAssaultLarge0`, `ConquestAssaultSmall0`, `ConquestAssaultSmall1`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0` |
-| `XP2_Factory` | `TeamDeathMatchC0`, `GunMaster0`, `Domination0`, `SquadDeathMatch0` |
-| `XP2_Office` | `TeamDeathMatchC0`, `GunMaster0`, `Domination0`, `SquadDeathMatch0` |
-| `XP2_Palace` | `TeamDeathMatchC0`, `GunMaster0`, `Domination0`, `SquadDeathMatch0` |
-| `XP2_Skybar` | `TeamDeathMatchC0`, `GunMaster0`, `Domination0`, `SquadDeathMatch0` |
-| `XP3_Desert` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0`, `TankSuperiority0` |
-| `XP3_Alborz` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0`, `TankSuperiority0` |
-| `XP3_Shield` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0`, `TankSuperiority0` |
-| `XP3_Valley` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0`, `TankSuperiority0` |
-| `XP4_Quake` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0`, `GunMaster0`, `Scavenger0` |
-| `XP4_FD` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0`, `GunMaster0`, `Scavenger0` |
-| `XP4_Parl` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0`, `GunMaster0`, `Scavenger0` |
-| `XP4_Rubble` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0`, `GunMaster0`, `Scavenger0` |
-| `XP5_001` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0`, `CaptureTheFlag0`, `AirSuperiority0` |
-| `XP5_002` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0`, `CaptureTheFlag0`, `AirSuperiority0` |
-| `XP5_003` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0`, `CaptureTheFlag0`, `AirSuperiority0` |
-| `XP5_004` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadRush0`, `SquadDeathMatch0`, `TeamDeathMatch0`, `CaptureTheFlag0`, `AirSuperiority0` |
+| `MP_001` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `MP_003` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `MP_007` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `MP_011` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `MP_012` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `MP_013` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `MP_017` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `MP_018` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `MP_Subway` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP1_001` | `ConquestAssaultLarge0`, `ConquestAssaultSmall0`, `ConquestAssaultSmall1`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP1_002` | `ConquestAssaultSmall0`, `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP1_003` | `ConquestAssaultLarge0`, `ConquestAssaultSmall0`, `ConquestAssaultSmall1`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP1_004` | `ConquestAssaultLarge0`, `ConquestAssaultSmall0`, `ConquestAssaultSmall1`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP2_Factory` | `Domination0`, `GunMaster0`, `SquadDeathMatch0`, `TeamDeathMatchC0` |
+| `XP2_Office` | `Domination0`, `GunMaster0`, `SquadDeathMatch0`, `TeamDeathMatchC0` |
+| `XP2_Palace` | `Domination0`, `GunMaster0`, `SquadDeathMatch0`, `TeamDeathMatchC0` |
+| `XP2_Skybar` | `Domination0`, `GunMaster0`, `SquadDeathMatch0`, `TeamDeathMatchC0` |
+| `XP3_Desert` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TankSuperiority0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP3_Alborz` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TankSuperiority0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP3_Shield` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TankSuperiority0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP3_Valley` | `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TankSuperiority0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP4_Quake` | `ConquestLarge0`, `ConquestSmall0`, `GunMaster0`, `RushLarge0`, `Scavenger0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP4_FD` | `ConquestLarge0`, `ConquestSmall0`, `GunMaster0`, `RushLarge0`, `Scavenger0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP4_Parl` | `ConquestLarge0`, `ConquestSmall0`, `GunMaster0`, `RushLarge0`, `Scavenger0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP4_Rubble` | `ConquestAssaultLarge0`, `ConquestAssaultSmall0`, `GunMaster0`, `RushLarge0`, `Scavenger0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP5_001` | `AirSuperiority0`, `CaptureTheFlag0`, `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP5_002` | `AirSuperiority0`, `CaptureTheFlag0`, `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP5_003` | `AirSuperiority0`, `CaptureTheFlag0`, `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |
+| `XP5_004` | `AirSuperiority0`, `CaptureTheFlag0`, `ConquestLarge0`, `ConquestSmall0`, `RushLarge0`, `SquadDeathMatch0`, `SquadRush0`, `TeamDeathMatch0`, `TeamDeathMatchC0` |


### PR DESCRIPTION
![Screenshot_18](https://user-images.githubusercontent.com/56718716/95692778-969c8f80-0c28-11eb-851c-487f163a4a44.jpg)

Renaming `Conquest Assault (alt.)` to `Conquest Assault: Day 2` because that's the name.