### PR TITLE
winepath trick for to find serverInstancePath

### DIFF
--- a/content/hosting/setup-linux.md
+++ b/content/hosting/setup-linux.md
@@ -102,6 +102,14 @@ You are now ready to run a VU server. To do so, use the command below:
 wine ~/vu/client/vu.com -gamepath ~/bf3 -serverInstancePath ~/vu/instance -server -dedicated
 ```
 
+> In some cases, you might encounter an issue in the serverInstancePath processing, resulting on a unreadable server.key error printing the following log :
+>`[error] Server key file not found or invalid. Shutting down.`
+> The work around would be to use the windows path instead of an absolute path for serverInstancePath, you can get it by running `winepath -w <instance_directory_path>` or use the command below :
+
+```
+wine ~/vu/client/vu.com -gamepath ~/bf3 -serverInstancePath "$(winepath -w ~/vu/instance)" -server -dedicated
+```
+
 Your server will start up and will soon be joinable by players. It is recommended to restart your server every now and then so you can receive updates and fixes.
 
 ## Port forwarding


### PR DESCRIPTION
Adding the winepath tip shared by NoFate for the unreadable server.key error that might happen. 
Cf Discord  17/10 10 P.M UTC+1 | Channel server-hosting