### PR TITLE
add `Player | nil` for `Player:Chat`

### DIFF
--- a/content/vext/ref/server/event/player_chat.md
+++ b/content/vext/ref/server/event/player_chat.md
@@ -8,7 +8,7 @@ title: Player:Chat
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| **player** | [Player](/vext/ref/server/type/player) |  |
+| **player** | [Player](/vext/ref/server/type/player) \| nil |  |
 | **recipientMask** | int |  |
 | **message** | string |  |
 

--- a/types/server/event/Player_Chat.yaml
+++ b/types/server/event/Player_Chat.yaml
@@ -4,6 +4,7 @@ type: event
 params:
   player:
     type: Player
+    nullable: true
   recipientMask:
     type: int
   message:


### PR DESCRIPTION
`player` can also be `nil` in `Player:Chat(player, recipientMask, message)` if you send a message via RCON.
#62