### PR TITLE
fix(RagdollComponent): Remove duplicated methods

### DIFF
--- a/content/vext/ref/client/type/ragdollcomponent.md
+++ b/content/vext/ref/client/type/ragdollcomponent.md
@@ -28,8 +28,6 @@ title: RagdollComponent
 | **[SetActiveWorldTransform](#setactiveworldtransform)**(boneId: int, transform: [QuatTransform](/vext/ref/shared/type/quattransform)) | void |
 | **[GetActiveLocalTransform](#getactivelocaltransform)**(boneId: int) | [QuatTransform](/vext/ref/shared/type/quattransform) \| nil |
 | **[SetActiveLocalTransform](#setactivelocaltransform)**(boneId: int, transform: [QuatTransform](/vext/ref/shared/type/quattransform)) | void |
-| **[GetLocalTransform](#getlocaltransform-1)**(boneId: int) | [QuatTransform](/vext/ref/shared/type/quattransform) \| nil |
-| **[SetLocalTransform](#setlocaltransform-1)**(boneId: int, transform: [QuatTransform](/vext/ref/shared/type/quattransform)) | void |
 | **[GetBoneVelocity](#getbonevelocity)**(boneId: int) | [QuatTransform](/vext/ref/shared/type/quattransform) \| nil |
 | **[SetBoneVelocity](#setbonevelocity)**(boneId: int, transform: [QuatTransform](/vext/ref/shared/type/quattransform)) | void |
 
@@ -222,33 +220,6 @@ title: RagdollComponent
 ### SetActiveLocalTransform {#setactivelocaltransform}
 
 > **SetActiveLocalTransform**(boneId: int, transform: [QuatTransform](/vext/ref/shared/type/quattransform))
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| **boneId** | int |  |
-| **transform** | [QuatTransform](/vext/ref/shared/type/quattransform) |  |
-
-### GetLocalTransform {#getlocaltransform-1}
-
-> **GetLocalTransform**(boneId: int): [QuatTransform](/vext/ref/shared/type/quattransform) \| nil
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| **boneId** | int |  |
-
-#### Returns
-
-| Type | Description |
-| ---- | ----------- |
-| **[QuatTransform](/vext/ref/shared/type/quattransform)** \| **nil** |  |
-
-### SetLocalTransform {#setlocaltransform-1}
-
-> **SetLocalTransform**(boneId: int, transform: [QuatTransform](/vext/ref/shared/type/quattransform))
 
 #### Parameters
 

--- a/types/client/type/RagdollComponent.yaml
+++ b/types/client/type/RagdollComponent.yaml
@@ -114,21 +114,6 @@ methods:
       transform:
         type: QuatTransform
   -
-    name: GetLocalTransform
-    params:
-      boneId:
-        type: int
-    returns:
-      type: QuatTransform
-      nullable: true
-  -
-    name: SetLocalTransform
-    params:
-      boneId:
-        type: int
-      transform:
-        type: QuatTransform
-  -
     name: GetBoneVelocity
     params:
       boneId:


### PR DESCRIPTION
fix #73
- GetLocalTransform
- SetLocalTransform
These methods were listed twice here.

Related VU issue: https://github.com/EmulatorNexus/VeniceUnleashed/issues/672