### PR TITLE
Hide unused navbar container

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -22,6 +22,10 @@
   margin-bottom: 20px;
 }
 
+#main_navbar {
+  display: none;
+}
+
 body {
   color: rgba(255, 255, 255, 0.8);
   background-color: #121212;


### PR DESCRIPTION
Hid the navbar links container that messed up the navbar on mobile
![chrome_5hF17BGnws](https://user-images.githubusercontent.com/43269060/171950298-50d43870-8b90-49c2-be36-3b40d5744a13.png)

